### PR TITLE
Version 9.0.2.2508

### DIFF
--- a/InternetTest/InternetTest/App.xaml.cs
+++ b/InternetTest/InternetTest/App.xaml.cs
@@ -37,38 +37,45 @@ public partial class App : Application
 {
 	protected override async void OnStartup(StartupEventArgs e)
 	{
-		// Load settings
-		Settings settings = new();
-		settings.Load();
-
-		ActivityHistory history = await ActivityHistory.LoadAsync();
-
-		ThemeHelper.ChangeTheme(settings.Theme);
-		Context.ChangeLanguage(settings.Language);
-
-		// Set the main window
-		if (settings.IsFirstRun)
+		try
 		{
-			MainWindow = new OobeWindow
+			// Load settings
+			Settings settings = new();
+			settings.Load();
+
+			ActivityHistory history = await ActivityHistory.LoadAsync();
+
+			ThemeHelper.ChangeTheme(settings.Theme);
+			Context.ChangeLanguage(settings.Language);
+
+			// Set the main window
+			if (settings.IsFirstRun)
 			{
-				DataContext = new OobeWindowViewModel(settings)
+				MainWindow = new OobeWindow
+				{
+					DataContext = new OobeWindowViewModel(settings)
+				};
+				MainWindow.Show();
+				base.OnStartup(e);
+
+				return;
+			}
+
+			MainWindow = new MainWindow()
+			{
+				Width = settings.MainWindowSize?.Item1 ?? 950,
+				Height = settings.MainWindowSize?.Item2 ?? 600,
 			};
+			MainViewModel mvm = new(settings, history, MainWindow);
+			MainWindow.DataContext = mvm;
+
 			MainWindow.Show();
+
 			base.OnStartup(e);
-
-			return;
 		}
-
-		MainWindow = new MainWindow()
+		catch (Exception ex)
 		{
-			Width = settings.MainWindowSize?.Item1 ?? 950,
-			Height = settings.MainWindowSize?.Item2 ?? 600,
-		};
-		MainViewModel mvm = new(settings, history, MainWindow);
-		MainWindow.DataContext = mvm;
-
-		MainWindow.Show();
-
-		base.OnStartup(e);
+			MessageBox.Show(ex.Message, InternetTest.Properties.Resources.Error, MessageBoxButton.OK, MessageBoxImage.Error);
+		}
 	}
 }

--- a/InternetTest/InternetTest/Helpers/Context.cs
+++ b/InternetTest/InternetTest/Helpers/Context.cs
@@ -29,7 +29,7 @@ namespace InternetTest.Helpers;
 
 public static class Context
 {
-	public static string Version => "9.0.0.2508";
+	public static string Version => "9.0.1.2508";
 
 #if PORTABLE
 	public static string DefaultStoragePath => $@"{FileSys.CurrentDirectory}\InternetTest Pro\";

--- a/InternetTest/InternetTest/Helpers/Context.cs
+++ b/InternetTest/InternetTest/Helpers/Context.cs
@@ -29,7 +29,7 @@ namespace InternetTest.Helpers;
 
 public static class Context
 {
-	public static string Version => "9.0.1.2508";
+	public static string Version => "9.0.2.2508";
 
 #if PORTABLE
 	public static string DefaultStoragePath => $@"{FileSys.CurrentDirectory}\InternetTest Pro\";

--- a/InternetTest/InternetTest/Helpers/XmlHelper.cs
+++ b/InternetTest/InternetTest/Helpers/XmlHelper.cs
@@ -34,7 +34,13 @@ public static class XmlHelper
 		{
 			XmlSerializer serializer = new(typeof(T));
 			using StreamReader reader = new(filepath);
-			return (T?)serializer.Deserialize(reader);
+
+			var o = (T?)serializer.Deserialize(reader);
+
+			reader.Close();
+			reader.Dispose();
+
+			return o;
 		});
 	}
 }

--- a/InternetTest/InternetTest/InternetTest.csproj
+++ b/InternetTest/InternetTest/InternetTest.csproj
@@ -8,7 +8,7 @@
 	<UseWPF>true</UseWPF>
 	<ApplicationIcon>InternetTest.ico</ApplicationIcon>
 	<ApplicationManifest>app.manifest</ApplicationManifest>
-	<Version>9.0.1.2508</Version>
+	<Version>9.0.2.2508</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/InternetTest/InternetTest/InternetTest.csproj
+++ b/InternetTest/InternetTest/InternetTest.csproj
@@ -8,7 +8,7 @@
 	<UseWPF>true</UseWPF>
 	<ApplicationIcon>InternetTest.ico</ApplicationIcon>
 	<ApplicationManifest>app.manifest</ApplicationManifest>
-	<Version>9.0.0.2508</Version>
+	<Version>9.0.1.2508</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/InternetTest/InternetTest/Models/ActivityHistory.cs
+++ b/InternetTest/InternetTest/Models/ActivityHistory.cs
@@ -60,6 +60,7 @@ public class ActivityHistory
 		StreamWriter streamWriter = new(filePath);
 		xmlSerializer.Serialize(streamWriter, this);
 
+		streamWriter.Close();
 		streamWriter.Dispose();
 	}
 }

--- a/InternetTest/InternetTest/Models/Settings.cs
+++ b/InternetTest/InternetTest/Models/Settings.cs
@@ -103,12 +103,16 @@ public class Settings
 		{
 			using var writer = new StreamWriter(filePath);
 			new XmlSerializer(typeof(Settings)).Serialize(writer, new Settings());
+			writer.Close();
+			writer.Dispose();
 		}
 
 		Settings settings;
 		using (var reader = new StreamReader(filePath))
 		{
 			settings = (Settings?)new XmlSerializer(typeof(Settings)).Deserialize(reader) ?? new Settings();
+			reader.Close();
+			reader.Dispose();
 		}
 
 		// Upgrade defaults in one go if they're null

--- a/InternetTest/InternetTest/Models/WiFiNetwork.cs
+++ b/InternetTest/InternetTest/Models/WiFiNetwork.cs
@@ -55,34 +55,41 @@ public class WiFiNetwork
 
 	public static List<WiFiNetwork> GetWiFis()
 	{
-		var availableNetworks = NativeWifi.EnumerateAvailableNetworks()
-			.Select(x => new WiFiNetwork
-			{
-				Ssid = x.Ssid.ToString(),
-				SignalQuality = x.SignalQuality,
-				BssType = x.BssType,
-				IsSecurityEnabled = x.IsSecurityEnabled,
-				ProfileName = x.ProfileName,
-				InterfaceDescription = x.InterfaceInfo.Description,
-				Interface = x.InterfaceInfo
-			})
-			.ToList();
-
-		var bssNetworks = NativeWifi.EnumerateBssNetworks()
-			.Select(x => new { x.Ssid, x.Channel, x.Band, x.Frequency })
-			.ToList();
-
-		foreach (var network in availableNetworks)
+		try
 		{
-			var bssNetwork = bssNetworks.FirstOrDefault(x => x.Ssid.ToString() == network.Ssid);
-			if (bssNetwork != null)
+			var availableNetworks = NativeWifi.EnumerateAvailableNetworks()
+				.Select(x => new WiFiNetwork
+				{
+					Ssid = x.Ssid.ToString(),
+					SignalQuality = x.SignalQuality,
+					BssType = x.BssType,
+					IsSecurityEnabled = x.IsSecurityEnabled,
+					ProfileName = x.ProfileName,
+					InterfaceDescription = x.InterfaceInfo.Description,
+					Interface = x.InterfaceInfo
+				})
+				.ToList();
+
+			var bssNetworks = NativeWifi.EnumerateBssNetworks()
+				.Select(x => new { x.Ssid, x.Channel, x.Band, x.Frequency })
+				.ToList();
+
+			foreach (var network in availableNetworks)
 			{
-				network.Channel = bssNetwork.Channel;
-				network.Frequency = bssNetwork.Frequency;
-				network.Band = bssNetwork.Band;
+				var bssNetwork = bssNetworks.FirstOrDefault(x => x.Ssid.ToString() == network.Ssid);
+				if (bssNetwork != null)
+				{
+					network.Channel = bssNetwork.Channel;
+					network.Frequency = bssNetwork.Frequency;
+					network.Band = bssNetwork.Band;
+				}
 			}
+			return availableNetworks;
 		}
-		return availableNetworks;
+		catch
+		{
+			return [];
+		}
 	}
 
 	public async Task<bool> ConnectAsync(string password = "")

--- a/InternetTest/InternetTest/Properties/Resources.it-IT.resx
+++ b/InternetTest/InternetTest/Properties/Resources.it-IT.resx
@@ -571,7 +571,7 @@ Questa azione non può essere annullata.</value>
     <value>Vuoi ignorare questa finestra e continuare con InternetTest?</value>
   </data>
   <data name="WelcomeDesc" xml:space="preserve">
-    <value>I tuoi strumenti Internet, tutti in un unico posto moderno.</value>
+    <value>I tuoi strumenti Internet, tutti in un unico programma moderno.</value>
   </data>
   <data name="Next" xml:space="preserve">
     <value>Avanti</value>
@@ -1237,13 +1237,13 @@ Assolutamente NESSUN dato verrà inviato a Léo Corporation.</value>
     <value>Tasso di perdita</value>
   </data>
   <data name="StartTime" xml:space="preserve">
-    <value>Ora di inizio</value>
+    <value>Ora inizio</value>
   </data>
   <data name="IpConfigAdaptersDesc" xml:space="preserve">
-    <value>Riepilogo di tutte le schede di rete presenti su questo sistema.</value>
+    <value>Riepilogo schede di rete presenti in questo sistema.</value>
   </data>
   <data name="IpConfigDesc" xml:space="preserve">
-    <value>Visualizza le informazioni di configurazione della scheda di rete.</value>
+    <value>Visualizza informazioni configurazione scheda di rete.</value>
   </data>
   <data name="RequestsDesc" xml:space="preserve">
     <value>Effettua una richiesta HTTP a un URL specifico.</value>
@@ -1252,7 +1252,7 @@ Assolutamente NESSUN dato verrà inviato a Léo Corporation.</value>
     <value>Impostazioni richiesta</value>
   </data>
   <data name="RequestSettingsDesc" xml:space="preserve">
-    <value>Fornisci qui tutte le informazioni relative alla tua richiesta.</value>
+    <value>Vengono riportate qui tutte le informazioni relative alla richiesta.</value>
   </data>
   <data name="ResponseDesc" xml:space="preserve">
     <value>Informazioni sulla risposta - Stato {0}.</value>
@@ -1264,7 +1264,7 @@ Assolutamente NESSUN dato verrà inviato a Léo Corporation.</value>
     <value>Traccia il percorso di rete verso qualsiasi destinazione.</value>
   </data>
   <data name="TracerouteConfiguration" xml:space="preserve">
-    <value>Configurazione Traceroute</value>
+    <value>Configurazione traceroute</value>
   </data>
   <data name="TargetHostname" xml:space="preserve">
     <value>Destinazione (IP o nome host)</value>
@@ -1273,22 +1273,22 @@ Assolutamente NESSUN dato verrà inviato a Léo Corporation.</value>
     <value>Analisi completa del percorso fino a {0}</value>
   </data>
   <data name="TotalHops" xml:space="preserve">
-    <value>Totale luppolo</value>
+    <value>Totale hop</value>
   </data>
   <data name="MaxHopsS" xml:space="preserve">
     <value>Numero massimo: {0}</value>
   </data>
   <data name="SuccessfulHops" xml:space="preserve">
-    <value>Luppolo di successo</value>
+    <value>Hop compleati</value>
   </data>
   <data name="StartedTime" xml:space="preserve">
-    <value>Iniziato: {0}</value>
+    <value>Avviato: {0}</value>
   </data>
   <data name="Target" xml:space="preserve">
     <value>Obiettivo</value>
   </data>
   <data name="DownDetectorDesc" xml:space="preserve">
-    <value>Monitorare facilmente lo stato di inattività di qualsiasi sito web.</value>
+    <value>Monitora facilmente lo stato di inattività di qualsiasi sito web.</value>
   </data>
   <data name="Websites" xml:space="preserve">
     <value>Siti web</value>
@@ -1312,7 +1312,7 @@ Assolutamente NESSUN dato verrà inviato a Léo Corporation.</value>
     <value>Valore</value>
   </data>
   <data name="LightDesc" xml:space="preserve">
-    <value>Interfaccia luminosa</value>
+    <value>Chiara e luminosa</value>
   </data>
   <data name="DarkDesc" xml:space="preserve">
     <value>Piacevole la sera</value>

--- a/InternetTest/InternetTest/ViewModels/Components/ConnectWiFiItemViewModel.cs
+++ b/InternetTest/InternetTest/ViewModels/Components/ConnectWiFiItemViewModel.cs
@@ -136,7 +136,7 @@ public class ConnectWiFiItemViewModel : ViewModelBase
 			MessageBox.Show(Properties.Resources.NotConnected);
 		}
 
-		_wiFiPageViewModel.RefreshWiFi();
+		_wiFiPageViewModel.RefreshWiFi(false);
 	}
 
 	private async void ConnectPopup(object? o)

--- a/InternetTest/InternetTest/ViewModels/Components/WebsiteItemViewModel.cs
+++ b/InternetTest/InternetTest/ViewModels/Components/WebsiteItemViewModel.cs
@@ -81,7 +81,7 @@ public class WebsiteItemViewModel : ViewModelBase
 			var statusInfo = await Internet.GetStatusInfoAsync(Url);
 			var endTime = DateTime.Now;
 
-			StatusCode = statusInfo.StatusCode;
+			StatusCode = statusInfo?.StatusCode ?? 400;
 
 			StatusBackground = StatusCode switch
 			{
@@ -98,18 +98,35 @@ public class WebsiteItemViewModel : ViewModelBase
 			};
 
 			Details = [
-				new(Properties.Resources.StatusMessage, statusInfo.StatusDescription, 0, 0),
+				new(Properties.Resources.StatusMessage, statusInfo?.StatusDescription ?? Properties.Resources.Failed, 0, 0),
 				new(Properties.Resources.TimeElapsed,  $"{(endTime - startTime).TotalMilliseconds:0} ms", 0,1 ),
 			];
 
-			_history.Activity.Add(new Activity(Url, statusInfo.StatusCode.ToString(), statusInfo.StatusCode switch
+			_history.Activity.Add(new Activity(Url, (StatusCode).ToString(), StatusCode switch
 			{
 				>= 400 => false,
 				>= 300 or <= 100 => null,
 				_ => true,
 			}, DateTime.Now));
 		}
-		catch { }
+		catch
+		{
+			StatusCode = 400;
+
+			StatusBackground = StatusCode switch
+			{
+				>= 400 => ThemeHelper.GetSolidColorBrush("LightOrange"),
+				>= 300 => ThemeHelper.GetSolidColorBrush("DarkFAccent"),
+				_ => ThemeHelper.GetSolidColorBrush("LightGreen"),
+			};
+
+			StatusForeground = StatusCode switch
+			{
+				>= 400 => ThemeHelper.GetSolidColorBrush("ForegroundOrange"),
+				>= 300 => ThemeHelper.GetSolidColorBrush("LightAccent"),
+				_ => ThemeHelper.GetSolidColorBrush("ForegroundGreen"),
+			};
+		}
 		ShowStatusCode = true;
 	}
 

--- a/InternetTest/InternetTest/ViewModels/Oobe/JumpInPageViewModel.cs
+++ b/InternetTest/InternetTest/ViewModels/Oobe/JumpInPageViewModel.cs
@@ -37,6 +37,7 @@ public class JumpInPageViewModel(OobeWindowViewModel oobe)
 		oobe.Settings.IsFirstRun = false;
 		oobe.Settings.Save();
 		Process.Start(FileSys.CurrentAppDirectory + @"\InternetTest.exe");
+		Application.Current.MainWindow?.Close();
 		Application.Current.Shutdown(0);
 	});
 }

--- a/InternetTest/InternetTest/ViewModels/Oobe/WelcomePageViewModel.cs
+++ b/InternetTest/InternetTest/ViewModels/Oobe/WelcomePageViewModel.cs
@@ -54,6 +54,7 @@ public class WelcomePageViewModel : ViewModelBase
 		_settings.Save();
 
 		Process.Start(FileSys.CurrentAppDirectory + @"\InternetTest.exe");
+		Application.Current.MainWindow?.Close();
 		Application.Current.Shutdown(0);
 	});
 	public WelcomePageViewModel(OobeWindowViewModel oobe)

--- a/InternetTest/InternetTest/ViewModels/WiFiPageViewModel.cs
+++ b/InternetTest/InternetTest/ViewModels/WiFiPageViewModel.cs
@@ -132,25 +132,30 @@ public class WiFiPageViewModel : ViewModelBase, ISensitiveViewModel
 
 		GetAdapters();
 
-		string? currentSsid = NetworkHelper.GetCurrentWifiSSID();
-		WiFiNetworks = [.. WiFiNetwork.GetWiFis().Select(x => new ConnectWiFiItemViewModel(x, currentSsid, this))];
-		_connectWiFis = [.. WiFiNetworks];
-		NoNetworks = WiFiNetworks.Count == 0;
+		RefreshWiFi(false);
 
 		RefreshProfiles();
 	}
 
-	internal async void RefreshWiFi()
+	internal async void RefreshWiFi(bool scan = true)
 	{
 		Query = string.Empty;
 		WiFiNetworks.Clear();
 		NoNetworks = false;
 		IsRefreshing = true;
 
-		await NativeWifi.ScanNetworksAsync(TimeSpan.FromSeconds(10));
+		try
+		{
+			if (scan)
+				await NativeWifi.ScanNetworksAsync(TimeSpan.FromSeconds(10));
 
-		string? currentSsid = NetworkHelper.GetCurrentWifiSSID();
-		WiFiNetwork.GetWiFis().ForEach(x => WiFiNetworks.Add(new ConnectWiFiItemViewModel(x, currentSsid, this)));
+			string? currentSsid = NetworkHelper.GetCurrentWifiSSID();
+			WiFiNetwork.GetWiFis().ForEach(x => WiFiNetworks.Add(new ConnectWiFiItemViewModel(x, currentSsid, this)));
+		}
+		catch (Exception ex)
+		{
+			MessageBox.Show(ex.Message, Properties.Resources.Error, MessageBoxButton.OK, MessageBoxImage.Error);
+		}
 
 		_connectWiFis = [.. WiFiNetworks];
 		IsRefreshing = false;


### PR DESCRIPTION
_Second attempt to fix issue #687._

This pull request introduces several improvements focused on resource management, error handling, and minor updates to localization and versioning. The most significant changes are the addition of explicit resource disposal for file streams, enhanced error handling throughout the application, and updates to Italian translations and version numbers.

**Resource Management and Stability Improvements**
* Added explicit calls to `Close()` and `Dispose()` for `StreamReader`, `StreamWriter`, and other file stream objects in methods across `XmlHelper.cs`, `ActivityHistory.cs`, and `Settings.cs` to ensure proper resource cleanup and prevent file access issues. [[1]](diffhunk://#diff-5919c55d5feebabb18a4332d04dc473bd7e89e05c8a54d308fa790b6da98d40bL37-R43) [[2]](diffhunk://#diff-0e0d426895b602777ffc32bb2f7314cd05bd57d024f16500b88fde947db3d9b0R63) [[3]](diffhunk://#diff-7832b0eaaa448c7233e2174f481fa07051f38861bf1664f160c3998cadd69b1bR106-R115)
* Wrapped Wi-Fi network enumeration and DNS info/record retrieval in try-catch blocks, returning empty lists or showing error messages as needed to improve robustness against runtime errors. [[1]](diffhunk://#diff-5567ac4a6c5d3a84869639b07b022934d2e8e63479df91549a12932f3888181dR57-R58) [[2]](diffhunk://#diff-5567ac4a6c5d3a84869639b07b022934d2e8e63479df91549a12932f3888181dR89-R93) [[3]](diffhunk://#diff-ac3e1c6d792969ccf9d39a2c091e74a79d5115e69a9e3f86962800cd4b9be63aL156-R163) [[4]](diffhunk://#diff-ac3e1c6d792969ccf9d39a2c091e74a79d5115e69a9e3f86962800cd4b9be63aR201-R202) [[5]](diffhunk://#diff-ac3e1c6d792969ccf9d39a2c091e74a79d5115e69a9e3f86962800cd4b9be63aL222-R233) [[6]](diffhunk://#diff-ac3e1c6d792969ccf9d39a2c091e74a79d5115e69a9e3f86962800cd4b9be63aR256-R260)

**Error Handling Enhancements**
* Added global exception handling to the application startup in `App.xaml.cs`, ensuring users are notified of any startup issues via a message box. [[1]](diffhunk://#diff-8de473ca05f48b8e7dab27c50ad21a115d1d4bb5e3f39590626d7d0f556f1603R39-R40) [[2]](diffhunk://#diff-8de473ca05f48b8e7dab27c50ad21a115d1d4bb5e3f39590626d7d0f556f1603R76-R80)
* Improved error handling in website status checks to assign default values and display appropriate UI feedback if requests fail. [[1]](diffhunk://#diff-54b89d82f9b997154ef99340fc96520d883a1411e52201dff7e084137be528ccL84-R84) [[2]](diffhunk://#diff-54b89d82f9b997154ef99340fc96520d883a1411e52201dff7e084137be528ccL101-R129)

**Localization and Versioning Updates**
* Updated Italian translations in `Resources.it-IT.resx` for clarity and accuracy. [[1]](diffhunk://#diff-f5175e659d8d4aca791d3924292a04f67a216852f40cb7ceca67ac88ebd1d98bL574-R574) [[2]](diffhunk://#diff-f5175e659d8d4aca791d3924292a04f67a216852f40cb7ceca67ac88ebd1d98bL1240-R1246) [[3]](diffhunk://#diff-f5175e659d8d4aca791d3924292a04f67a216852f40cb7ceca67ac88ebd1d98bL1255-R1255) [[4]](diffhunk://#diff-f5175e659d8d4aca791d3924292a04f67a216852f40cb7ceca67ac88ebd1d98bL1267-R1267) [[5]](diffhunk://#diff-f5175e659d8d4aca791d3924292a04f67a216852f40cb7ceca67ac88ebd1d98bL1276-R1291) [[6]](diffhunk://#diff-f5175e659d8d4aca791d3924292a04f67a216852f40cb7ceca67ac88ebd1d98bL1315-R1315)
* Bumped application version from `9.0.1.2508` to `9.0.2.2508` in both code and project files. [[1]](diffhunk://#diff-1ef23b3c5ef182d2205fcf04cf965f53df4f68c934133c90706c9fd5ed9025d9L32-R32) [[2]](diffhunk://#diff-042d3470c38c52763422303286dc6863e69822facd0f2aa9c1e9c296efc8beefL11-R11)

**UI/UX and Application Flow**
* Ensured the main window is closed before application shutdown in OOBE-related view models for smoother user experience. [[1]](diffhunk://#diff-4dc2b2ee6df6ab98250310a32f3403d3149d0d258252e5dd879181d4421f2258R40) [[2]](diffhunk://#diff-0ab07e3fdc6b80408256589e1f75d09b3a6ee254884c0487d42b54b7d719d315R57)
* Modified Wi-Fi refresh logic to optionally skip scanning and handle errors gracefully, improving performance and stability. [[1]](diffhunk://#diff-ccc3a9e398340c4a6589e4571bf72c6b9abedd56809bae8c0ae7e4ea954bea97L135-R158) [[2]](diffhunk://#diff-1c99824c131f12b439912d80c272c16bbe0aa7cc403cadcab54cb568b49bf035L139-R139)